### PR TITLE
Added License files for CORDEX groups 

### DIFF
--- a/web/WEB-INF/views/jsp/registration-request.jsp
+++ b/web/WEB-INF/views/jsp/registration-request.jsp
@@ -151,6 +151,12 @@
 			} else if (group=='CMIP5 Commercial') {
 				// retrieve specified license
 				showLicense("licenses/ipccCommercialLicense.xml");
+			} else if (group=='CORDEX_Research') {
+				// retrieve specified license
+				showLicense("licenses/CordexResearchLicense.xml");
+			} else if (group=='CORDEX_Commercial') {
+				// retrieve specified license
+				showLicense("licenses/CordexCommercialLicense.xml");
 			} else {
 				// submit the form
 				formObj.submit();

--- a/web/licenses/CordexCommercialLicense.xml
+++ b/web/licenses/CordexCommercialLicense.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<license>
+	<title>CORDEX Terms of use for unrestricted use of data</title>
+	<body>
+
+[N.B.  If you plan to limit your use of data to non-commercial educational and research 
+purposes, you should register for the "CORDEX_Research" group, not this one.  You will 
+then be given access to output from all the models.]
+
+a) I understand that the subset of CORDEX model output that will be made accessible to this group
+has been designated for "unrestricted" use.
+For both groups of users, the terms of use include these additional statements:
+
+b) I will hold no individual(s), organization(s), or group(s) responsible for any errors in the models
+or in their output data.
+
+c) In publications that rely on the CORDEX model output, I will appropriately credit the data
+providers by an acknowledgement similar to the following:
+"We acknowledge the World Climate Research Programme's Working Group on
+Regional Climate, and the Working Group on Coupled
+Modelling, former coordinating
+body of CORDEX and responsible panel for CMIP5. We
+also thank the climate
+modelling groups (listed in Table XX of this paper)
+for producing and making available
+their model output. We also acknowledge the Earth System Grid Federation
+infrastructure an international effort led by the U.S. Department of Energy's Program for
+Climate Model Diagnosis and Intercomparison, the European Network for Earth System
+Modelling and other partners in the Global Organisation for Earth System Science
+Portals (GO-ESSP)."
+where "Table XX" in your paper should list the models and modelling groups that provided the data
+you used.
+
+d) I acknowledge the potential limitations of the data obtained from this archive. These may include
+(but are not necessarily limited to) errors in the models, shortcomings in the experiment designs, the
+conjectural quality of the forcing scenarios used to drive the models, and statistical uncertainty of
+model results.
+
+e) I understand that although the model output has
+been subjected to a quality control procedure,
+unrecognized errors almost certainly remain.
+
+f) To aid participating groups in understanding and
+improving upon their models? behaviours, I will
+respond to reasonable requests from the WGCM or from CORDEX data providers for feedback
+about my CORDEX research results (e.g., reporting model deficiencies, recording CORDEX
+publications, etc.).
+
+g) I understand that Digital Object Identifiers (DOI's used, for example, in journal citations)
+together with a citation reference will be assigned
+to some of the CORDEX datasets during the
+DataCite data publication process, and when available and as appropriate, I will cite CORDEX data
+by these citation references in my publications.
+
+	</body>
+</license>

--- a/web/licenses/CordexResearchLicense.xml
+++ b/web/licenses/CordexResearchLicense.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<license>
+	<title>CORDEX terms of use for data limited to non-commercial research and educational purposes</title>
+	<body>
+
+[N.B.  If you plan to use your data for anything other than non-commercial research and 
+educational purposes, you should register for the "CORDEX_Commercial" group, not this 
+group.]
+
+a) I agree to restrict my use of CORDEX model output for non-commercial research and
+educational purposes only.
+Results from non-commercial research are expected to be made generally available through open
+publication and must not be considered proprietary.
+Materials prepared for educational purposes
+cannot be sold. These restrictions may only be relaxed by permission of the individual modelling
+groups responsible for the simulations.
+
+b) I will hold no individual(s), organization(s), or group(s) responsible for any errors in the models
+or in their output data.
+
+c) In publications that rely on the CORDEX model output, I will appropriately credit the data
+providers by an acknowledgement similar to the following:
+"We acknowledge the World Climate Research Programme's Working Group on
+Regional Climate, and the Working Group on Coupled
+Modelling, former coordinating
+body of CORDEX and responsible panel for CMIP5. We
+also thank the climate
+modelling groups (listed in Table XX of this paper)
+for producing and making available
+their model output. We also acknowledge the Earth System Grid Federation
+infrastructure an international effort led by the U.S. Department of Energy's Program for
+Climate Model Diagnosis and Intercomparison, the European Network for Earth System
+Modelling and other partners in the Global Organisation for Earth System Science
+Portals (GO-ESSP)."
+where "Table XX" in your paper should list the models and modelling groups that provided the data
+you used.
+
+d) I acknowledge the potential limitations of the data obtained from this archive. These may include
+(but are not necessarily limited to) errors in the models, shortcomings in the experiment designs, the
+conjectural quality of the forcing scenarios used to drive the models, and statistical uncertainty of
+model results.
+
+e) I understand that although the model output has
+been subjected to a quality control procedure,
+unrecognized errors almost certainly remain.
+
+f) To aid participating groups in understanding and
+improving upon their models? behaviours, I will
+respond to reasonable requests from the WGCM or from CORDEX data providers for feedback
+about my CORDEX research results (e.g., reporting model deficiencies, recording CORDEX
+publications, etc.).
+
+g) I understand that Digital Object Identifiers (DOIs used, for example, in journal citations)
+together with a citation reference will be assigned
+to some of the CORDEX datasets during the
+DataCite data publication process, and when available and as appropriate, I will cite CORDEX data
+by these citation references in my publications.
+
+	</body>
+</license>


### PR DESCRIPTION
Modified the registration-request.jsp file to 'offer' license files to inspect, for CORDEX_Research and CORDEX_Commercial groups. Also added are the license files themselves. 
