### PR TITLE
ORP drop down list config + SPECS licensing

### DIFF
--- a/bin/esg-orp
+++ b/bin/esg-orp
@@ -224,6 +224,8 @@ setup_orp() {
     popd >& /dev/null
     echo
 
+    setup_providers_dropdown
+
     get_orp_support_libs ${orp_service_app_home}/WEB-INF/lib
 
     write_orp_install_log
@@ -232,7 +234,30 @@ setup_orp() {
     return 0
 }
 
-# Takes the destination dirctory you wish to have supported libs checked and downloaded to
+setup_providers_dropdown() {
+
+    # Do additional setup to configure CEDA-provided ORP with a dropdown list of IDPs
+
+    known_providers_url="${esg_dist_url}/lists/esgf_known_providers.xml"
+    config_dir=${esg_root_dir}/config
+    known_providers_file=${config_dir}/esgf_known_providers.xml
+    local_idp_url=https://${esgf_host}/esgf-idp/openid/
+
+    # add /esg/config/ to common.loader in catalina.properties if not already present
+    perl -p -i -e "s@^(common\.loader=.*)\$@\1,$config_dir@ unless m{$config_dir}" ${tomcat_install_dir}/conf/catalina.properties
+
+    # install known providers file (fetch template file and substitute local IDP)
+    checked_get ${known_providers_file} ${known_providers_url} $((force_install))
+    perl -p -i -e "s,\@local_idp_name\@,$node_short_name,;s,\@local_idp_url\@,$local_idp_url," ${known_providers_file}
+
+    # and add orp.provider.list line in esgf.properties
+    config_file=$config_dir/esgf.properties
+    echo "orp.provider.list=${known_providers_file}" >> ${config_file}
+    dedup_properties ${config_file}
+    chown ${tomcat_user}:${tomcat_group} ${config_file}
+}
+
+# Takes the destination directory you wish to have supported libs checked and downloaded to
 # returns the number of files downloaded (in this case max of 2)
 #         0 if there was no update of libs necessary
 get_orp_support_libs() {

--- a/esgf_known_providers.xml
+++ b/esgf_known_providers.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OPS>
+ <OP>
+  <NAME>@local_idp_name@</NAME>
+  <URL>@local_idp_url@</URL>
+ </OP>
+ <OP>
+  <NAME>CCMC</NAME>
+  <URL>https://adm07.cmcc.it/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>CEDA</NAME>
+  <URL>https://ceda.ac.uk/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>DKRZ</NAME>
+  <URL>https://esgf-data.dkrz.de/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>IPSL</NAME>
+  <URL>https://esgf-node.ipsl.fr/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>JPL</NAME>
+  <URL>https://esg-datanode.jpl.nasa.gov/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>LIU</NAME>
+  <URL>https://esg-dn1.nsc.liu.se/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>NCCS</NAME>
+  <URL>https://esgf.nccs.nasa.gov/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>NCI</NAME>
+  <URL>https://esg2.nci.org.au/esgf-idp/openid/</URL>
+ </OP>
+ <OP>
+  <NAME>PCMDI</NAME>
+  <URL>https://pcmdi9.llnl.gov/esgf-idp/openid/</URL>
+ </OP>
+</OPS>

--- a/web/WEB-INF/views/jsp/registration-request.jsp
+++ b/web/WEB-INF/views/jsp/registration-request.jsp
@@ -157,6 +157,8 @@
 			} else if (group=='CORDEX_Commercial') {
 				// retrieve specified license
 				showLicense("licenses/CordexCommercialLicense.xml");
+			} else if (group=='SPECS') {
+			        showLicense("licenses/specs.xml");
 			} else {
 				// submit the form
 				formObj.submit();

--- a/web/licenses/specs.xml
+++ b/web/licenses/specs.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<license>
+  <title>SPECS terms of use</title>
+  <body>
+    <ul>
+      <li>
+	I agree to restrict my use of SPECS model output to non-commercial research and educational purposes only. Results from non-commercial research are expected to be made generally available through open-access
+publication and must not be considered proprietary. Materials prepared for educational purposes cannot be sold.
+These restrictions may only be relaxed by permission of the individual modelling groups responsible for the
+simulations.
+      </li>
+      <li>
+	I understand that my name and email address will be shared with SPECS data providers.
+	I will hold no individual(s), organization(s), or group(s) responsible for any errors in the models or in their output data.  
+      </li>
+      <li>
+	In publications that rely on the SPECS model output, I will appropriately credit the data providers by an acknowledgement similar to the following: "We acknowledge the SPECS project funded by the European Commission through the Seventh Framework Programme for Research, Theme Six-Environment (Grant Agreement 308378), and we thank the climate modelling groups (listed in Table XX of this paper) for producing and making available their model output." where "Table XX" in your paper should list the models and modelling groups that provided the data used.
+      </li>
+      <li>
+I acknowledge the potential limitations of the data obtained from this archive. These may include (but are not
+necessarily limited to) errors in the models, shortcomings in the experiment designs, the conjectural quality of
+the forcing scenarios used to drive the models, and so on.
+      </li>
+      <li>
+I understand that although the model output has been subjected to a quality control procedure, unrecognized
+errors almost certainly remain.
+      </li>
+      <li>
+To aid participating groups in understanding and improving upon their models behaviours, I will respond to
+reasonable requests from the SPECS project for feedback about my research results based on SPECS data (e.g.,
+reporting model deficiencies, recording SPECS publications, etc.).
+      </li>
+      <li>
+Although I may freely share downloaded SPECS data with close collaborators, I understand that I may not
+redistribute the data more widely before the end of the SPECS project (February 2017).
+      </li>
+    </ul>
+  </body>
+</license>


### PR DESCRIPTION
 * Added changes to esg-orp installation shell script to configure ORP with new ESGF known providers list XML file.  This is used to populate the new drop down list used in the ORP UI combobox.
 * Added details for SPECS licence agreement.